### PR TITLE
Link SignColumn coloring to LineNr

### DIFF
--- a/colors/baycomb.vim
+++ b/colors/baycomb.vim
@@ -23,6 +23,8 @@ endif
 
 let g:colors_name="baycomb"
 
+hi! link        SignColumn LineNr
+
 if &background == "dark"
 hi Normal       guifg=#a0b4e0 guibg=#11121a   "1a1823
 hi NonText      guifg=#382920 guibg=bg


### PR DESCRIPTION
I recently ran into https://github.com/airblade/vim-gitgutter/issues/696, which was caused by SignColumn not being set in this colorscheme.  I linked that to the LineNr group.